### PR TITLE
fix: pnpm v11 のビルドスクリプト承認設定を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@ RUN apk update && \
 
 WORKDIR /app
 
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 
-COPY package.json tsconfig.json ./
+COPY tsconfig.json ./
 COPY src src
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apk update && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \
   npm install -g corepack@latest && \
-  pnpm approve-builds && \
   corepack enable
 
 WORKDIR /app
@@ -23,8 +22,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 COPY package.json tsconfig.json ./
 COPY src src
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline && \
-  pnpm approve-builds
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
 
 ENV NODE_ENV=production
 ENV CONFIG_PATH=/data/config.json

--- a/package.json
+++ b/package.json
@@ -42,10 +42,5 @@
     "preinstall": "npx only-allow pnpm",
     "start": "tsx ./src/main.ts",
     "generate-schema": "typescript-json-schema --required src/config.ts IConfiguration -o schema/Configuration.json"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 allowBuilds:
   esbuild: true
+confirmModulesPurge: false


### PR DESCRIPTION
## 概要

pnpm v11 へのアップデートに伴い、ビルドスクリプトのデフォルトブロック機能への対応を行います。

## 変更内容

pnpm v11 では、セキュリティ向上のためパッケージのビルドスクリプトがデフォルトでブロックされるようになりました。これにより以下のエラーが発生します:

- `[ERR_PNPM_IGNORED_BUILDS]`: `pnpm install` でビルドスクリプトがブロックされる
- `[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY]`: Docker ビルド環境でインタラクティブな `pnpm approve-builds` が失敗

### 修正

1. `pnpm-workspace.yaml` に `allowBuilds` を追加し、必要なビルドスクリプトを明示的に許可
2. Dockerfile から `pnpm approve-builds` の呼び出しを削除（`allowBuilds` 設定で代替）

## 関連

- book000/book000#108

🤖 Generated with [Claude Code](https://claude.com/claude-code)