### PR TITLE
fix: TypeScript v6 対応のため tsconfig に ignoreDeprecations と rootDir を追加

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "es2020",
     "module": "commonjs",
     "moduleResolution": "Node",
+    "ignoreDeprecations": "6.0",
+    "rootDir": "./src",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
     "removeComments": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "bundler",
     "rootDir": "./src",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
-    "ignoreDeprecations": "6.0",
+    "moduleResolution": "bundler",
     "rootDir": "./src",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
@@ -24,11 +23,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
-    "newLine": "LF",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "newLine": "LF"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## 概要

TypeScript v6 へのアップグレード (Renovate PR #997) が以下のエラーで失敗していたため、`tsconfig.json` を修正します。

## 修正したエラー

| エラーコード | 内容 |
|---|---|
| `TS5107` | `moduleResolution=node10` が deprecated |
| `TS5101` | `baseUrl` が deprecated |
| `TS5011` | `rootDir` が未設定 |

## 変更内容

### `moduleResolution: "Node"` を削除

TypeScript v6 では `moduleResolution: "node10"` (および旧来のエイリアス `"Node"`) が deprecated になりました。
`moduleResolution` を省略することで:
- TypeScript v5: `module: "commonjs"` のデフォルト (`node10`) が適用される
- TypeScript v6: `module: "commonjs"` のデフォルト (`bundler`) が適用される

`moduleResolution: "bundler"` は TypeScript v5 では `module: "commonjs"` と組み合わせ不可 (`TS5095`) のため、明示指定を避けています。

### `baseUrl` と `paths` を削除

TypeScript v6 では `baseUrl` が deprecated になりました。`@/` パスエイリアスは `src/` 配下のどのファイルでも実際には使用されていないため、`baseUrl: "."` と `paths` の両方を削除しました。

### `rootDir: "./src"` を明示的に追加

`TS5011: 'rootDir' must be explicitly set` エラーを解消するため、`include: ["src/**/*"]` と一致する `"rootDir": "./src"` を追加しました。

## 確認事項

- `src/` 配下の全ファイル (`bsky.ts`, `config.ts`, `main.ts`, `notified.ts`) は相対インポートまたは外部パッケージを使用しており、`@/*` パスエイリアスは実際には使用されていません
- この変更は TypeScript v5 (現在の `5.9.3`) と v6 の両方で動作します
- `ignoreDeprecations: "6.0"` は TypeScript v5.x では `TS5103` エラーになるため使用しません

## 関連

- Renovate PR: #997 (`chore(deps): update dependency typescript to v6`)