### PR TITLE
fix: devcontainer の image を更新

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "watch-bsky-likes",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-18",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24",
   "remoteUser": "node",
   "otherPortsAttributes": {
     "onAutoForward": "silent"


### PR DESCRIPTION
## 概要

- devcontainer の image を旧形式（`:1-18`、`:0-18`、`:0-24`）から `:24` に更新

## 関連 Issue

- https://github.com/book000/book000/issues/118

🤖 Generated with [Claude Code](https://claude.com/claude-code)