### PR TITLE
fix: isImagePost が画像以外の embed 種別でクラッシュする問題を修正

### DIFF
--- a/src/bsky.ts
+++ b/src/bsky.ts
@@ -18,6 +18,40 @@ interface LikeResponse {
   cursor: string
 }
 
+// app.bsky.embed.images: 画像埋め込み
+interface ImagesEmbed {
+  $type: 'app.bsky.embed.images'
+  images: {
+    alt: string
+    aspectRatio: {
+      height: number
+      width: number
+    }
+    image: {
+      $type: string
+      ref: {
+        $link: string
+      }
+      mimeType: string
+      size: number
+    }
+  }[]
+}
+
+// app.bsky.embed.images 以外の既知の embed 種別（external / record / recordWithMedia / video）。
+// これらの内部構造（external.uri 等）は現状どのコードからも参照されていないため、
+// 判別に必要な $type のみを型に残す。実際にその embed の中身を扱う実装が
+// 追加されたタイミングで、該当の型を個別に定義する。
+interface NonImagesEmbed {
+  $type:
+    | 'app.bsky.embed.external'
+    | 'app.bsky.embed.record'
+    | 'app.bsky.embed.recordWithMedia'
+    | 'app.bsky.embed.video'
+}
+
+type Embed = ImagesEmbed | NonImagesEmbed
+
 interface Post {
   uri: string
   cid: string
@@ -43,24 +77,7 @@ interface Post {
   record: {
     $type: string
     createdAt: string
-    embed?: {
-      $type: string
-      images: {
-        alt: string
-        aspectRatio: {
-          height: number
-          width: number
-        }
-        image: {
-          $type: string
-          ref: {
-            $link: string
-          }
-          mimeType: string
-          size: number
-        }
-      }[]
-    }
+    embed?: Embed
     langs: string[]
     text: string
     facets?: {
@@ -121,23 +138,7 @@ interface Post {
 // 画像付きの投稿であることが保証される型
 type ImagePost = Post & {
   record: Post['record'] & {
-    embed: {
-      images: {
-        alt: string
-        aspectRatio: {
-          height: number
-          width: number
-        }
-        image: {
-          $type: string
-          ref: {
-            $link: string
-          }
-          mimeType: string
-          size: number
-        }
-      }[]
-    }
+    embed: ImagesEmbed
   }
 }
 
@@ -290,10 +291,15 @@ export class Bluesky {
   }
 
   public static isImagePost(post: Post): post is ImagePost {
-    if (!post.record.embed) {
+    const embed = post.record.embed
+    if (!embed) {
       return false
     }
 
-    return post.record.embed.images.length > 0
+    if (embed.$type !== 'app.bsky.embed.images') {
+      return false
+    }
+
+    return embed.images.length > 0
   }
 }

--- a/src/bsky.ts
+++ b/src/bsky.ts
@@ -38,7 +38,7 @@ interface ImagesEmbed {
   }[]
 }
 
-// app.bsky.embed.images 以外の既知の embed 種別（external / record / recordWithMedia / video）。
+// app.bsky.embed.images 以外の既知の embed 種別。
 // これらの内部構造（external.uri 等）は現状どのコードからも参照されていないため、
 // 判別に必要な $type のみを型に残す。実際にその embed の中身を扱う実装が
 // 追加されたタイミングで、該当の型を個別に定義する。


### PR DESCRIPTION
## 概要

`Bluesky.isImagePost`（`src/bsky.ts`）が、投稿の `record.embed` が `app.bsky.embed.images` 以外の種別（`app.bsky.embed.external` / `app.bsky.embed.record` / `app.bsky.embed.recordWithMedia` / `app.bsky.embed.video`）の場合に `TypeError: Cannot read properties of undefined (reading 'length')` を送出し、`unhandledRejection` としてプロセスがクラッシュする問題を修正します。

## 根本原因

`Post['record']['embed']` の型定義が実態を反映しておらず、`images` フィールドを必須として宣言していたため、`isImagePost` が `embed` の truthy チェックのみで `embed.images.length` にアクセスしてしまい、TypeScript の型チェックでもこのバグを検出できませんでした。

## 修正内容

- `Post['record']['embed']` を判別可能なユニオン型（discriminated union）`Embed = ImagesEmbed | NonImagesEmbed` として再定義。
  - `ImagesEmbed.$type` はリテラル `'app.bsky.embed.images'`。
  - `NonImagesEmbed.$type` は既知の 4 種類（`external`/`record`/`recordWithMedia`/`video`）のリテラルユニオン（`string` によるキャッチオールは判別可能ユニオンとしてのナローイングを壊すため不採用。`tsc --strict` で検証済み）。
- `isImagePost` を `embed.$type !== 'app.bsky.embed.images'` の判定で早期リターンするように変更し、`embed.images` へのアクセスを型安全にした（`as` によるキャスト不要）。
- `ImagePost` 型の `record.embed` を `ImagesEmbed` を直接参照する形に追従。

## スコープ

- 変更は `src/bsky.ts` のみ。`src/main.ts` からの呼び出し方に変更なし。
- `Post['embed']`（表示用にハイドレートされた embed）の union 化、`external`/`record`/`recordWithMedia`/`video` の内部構造の型定義、vitest 等のテスト追加は対象外（今回はスコープ外、または手動確認のみで担保）。

## 検証

- `pnpm lint:tsc` / `pnpm lint:eslint` / `pnpm lint:prettier`: すべて exit 0 を確認。
- 手動確認: `record.embed` が未定義 / `external` / `record` / `recordWithMedia` / `video` / `images`（空配列） / `images`（1 件以上）の各パターンでアドホックスクリプトを実行し、例外が発生せず期待通りの真偽値が返ることを確認。
- Deep Review（ローカル diff モード）を実施し、指摘事項（スコア 50 以上）はコミット済みで修正済み。

Closes #1205