### PR TITLE
chore: .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+data/config.json
+data/notified.json
+data/post_cache/


### PR DESCRIPTION
## 概要

`.worktreeinclude` を新規作成し、以下のパターンを追加しました。

- `data/config.json`
- `data/notified.json`
- `data/post_cache/`

## 背景・根拠

- README.md: 「`data/config.json` を作成し、Discord の通知設定を行います。」との記載があり、Discord の webhookUrl / token+channelId を含む設定例が示されている。
- `src/main.ts:9` で `new Configuration('data/config.json')` を読み込んでいる。
- `.gitignore` に `data/` が含まれており、ローカルの設定・状態ディレクトリとして gitignore されている。
- `src/notified.ts:5` で `NOTIFIED_FILE: process.env.NOTIFIED_FILE ?? 'data/notified.json'` を使用。
- `src/bsky.ts:151` で `POST_CACHE_PATH: process.env.POST_CACHE_PATH ?? 'data/post_cache/'` を使用。
- Dockerfile では `ENV CONFIG_PATH=/data/config.json` および `VOLUME [ "/data" ]` でホストの data ディレクトリをマウントしている。
- `.env`/`.env.example` は存在せず、設定は秘密情報を含む単一の JSON ファイル（dotenv 方式ではない）。

`data/config.json` は Discord の webhook URL や bot トークンを保持する手動作成 JSON ファイルであり、`.env` ではありません。`data/` ディレクトリ全体が gitignore されており、`notified.json` や `post_cache/` といったランタイム状態も含むため、worktree 間で継続性を保つために `data/` 配下をまとめて対象としています。テンプレート/サンプル設定ファイルは存在しないため、`.worktreeinclude` がない状態で新しい worktree を作成すると、README の手順に従って `data/config.json` を手動で再作成しない限りアプリケーションを実行できません。

## 関連 Issue

https://github.com/book000/book000/issues/132

---

### Lite Review

No issues found. Checked for CLAUDE.md compliance, bugs/correctness, code comment quality, and security.
