### PR TITLE
fix: main() 実行時の未処理の Promise rejection を捕捉する

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -62,5 +62,13 @@ async function main() {
 }
 
 ;(async () => {
-  await main()
+  try {
+    await main()
+  } catch (error) {
+    // fetch のネットワークエラーなどで main() が reject した場合、
+    // 未処理のまま unhandledRejection として落ちるのを防ぐ
+    const logger = Logger.configure('main')
+    logger.error('❌ Unhandled error in main', error as Error)
+    process.exitCode = 1
+  }
 })()


### PR DESCRIPTION
## 概要

fetch のネットワークエラーなど何らかの理由で `main()` が reject した場合、末尾の即時実行 async 関数に try/catch がなく、unhandledRejection として異常終了していた。

## 変更内容

- `src/main.ts` の起動処理を try/catch で囲み、エラーを `Logger` で記録した上で `process.exitCode = 1` にして正常にプロセスを終了させるように変更した。

## 動作確認

- `pnpm lint`(eslint / prettier / tsc)がすべて成功することを確認した。
- `pnpm start` を実行し、Config 読み込みで例外が発生するケースで、以前は未処理の rejection としてクラッシュしていたところが、エラーログを出力して exit code 1 で正常終了することを確認した。

GlitchTip Issue: https://glitchtip.orange.amatama.net/main/issues/4?project=9